### PR TITLE
Update dependency versions

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -5,7 +5,7 @@
   name="DroidTV"
   provider-name="Digitalhigh">
   <requires>
-    <import addon="xbmc.gui" version="5.10.0"/>
+    <import addon="xbmc.gui" version="5.12.0"/>
 		<import addon="script.toolbox" version="1.0.0"/>
 		<import addon="script.favourites" version="5.0.2"/>
 		<import addon="script.extendedinfo" version="2.0.3"/>


### PR DESCRIPTION
With the older versions, addon installation fails on kodi >=17.6